### PR TITLE
Handle null `platform.os.family`.

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,7 @@
 import platform from 'platform'
 
 let getPlatformName = function() {
-  let os = platform.os.family
+  let os = platform.os.family || ''
   os = os.toLowerCase().replace(/ /g, '')
   if (/\bwin/.test(os)) {
     os = 'windows'


### PR DESCRIPTION
This occurs for certain OSes, like Chrome OS.

Per platform documentation[0], `platform.os.family` can be a string OR `null`.

[0] https://github.com/bestiejs/platform.js/blob/master/doc/README.md#platformosfamily
